### PR TITLE
Anderson accelrated fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sitar
 SIngle isoTope sAha solveR. Also a stringed instrument from the Indian subcontinent.
 
-playing with making a Saha ionization solver
+a Saha ionization solver
 
 The figure below shows ionization fractions for unionized, singly, and doubly ionized Calcium.
 Compare to Figure 2.6 of "Supernovae and Nucleosynthesis", David Arnett.
@@ -19,20 +19,20 @@ Then an executable `saha` will be created in `build/src`.
 An observation: a Saha solver requires an iterative solver, such as Newton-Raphson.
 Implementing Anderson accelerated Newton-Raphson provides a roughly 4x speedup for the calculations above.
 
-# Testing
+## Testing
 Compilation and regression tests are run on each PR.
 
-# Code Style
+## Code Style
 
-We use `clang format` ((here)[https://clang.llvm.org/docs/ClangFormat.html]) 
-and `ruff` ((here)[https://docs.astral.sh/ruff/linter/]) for code cleanliness. 
+We use `clang format` ([here](https://clang.llvm.org/docs/ClangFormat.html)) 
+and `ruff` ([here](https://docs.astral.sh/ruff/linter/)) for code cleanliness. 
 C++ rules are listed in `.clang-format`.
 The current version of `clang-format` used is `clang-format-13`, probably.
 Simply call `tools/bash/format.sh` to format the `.hpp` and `.cpp` files.
 
 Python code linting and formatting is done with `ruff`. 
 Rules are listed in `ruff.toml`. 
-To check all python in the current directory, you may `ruff ..`
+To check all python in the current directory, you may `ruff .`
 To format a given file according to `ruff.toml`, run `ruff format file.py`. 
 
 Checks for formatting are performed on each PR.

--- a/src/saha.cpp
+++ b/src/saha.cpp
@@ -139,7 +139,7 @@ void SahaSolve( std::vector<Real> &ion_frac, Real Zbar, const Real temperature,
     //         : 0.25; // arbitrary guess: "high" Zbar above H ionization temp
     const Real guess = 0.5 * Z;
     // Zbar = FixedPointAA( Target, guess, temperature, atom, nk, min_state,
-    // max_state ); // FAILS
+    //                      max_state );
 
     Zbar = AANewton( Target, dTarget, guess, temperature, atom, nk, min_state,
                      max_state );

--- a/src/solve.hpp
+++ b/src/solve.hpp
@@ -34,6 +34,7 @@ T FixedPointAA( F target, T x0, Args... args ) {
   T xkm1, xk, xkp1;
   xk   = target( x0, args... ); // one fixed point step
   xkm1 = x0;
+  if ( std::fabs( xk - x0 ) <= Opts::FPTOL ) return xk;
   while ( n <= Opts::MAX_ITERS && error >= Opts::FPTOL ) {
     /* Anderson acceleration step */
     T alpha =
@@ -145,6 +146,7 @@ T AANewton( F target, F dTarget, T x0, Args... args ) {
   xk   = x0 - h;
   xkm1 = x0;
   T ans;
+  if ( std::fabs( xk - x0 ) <= Opts::FPTOL ) return xk;
   while ( n <= Opts::MAX_ITERS && error >= Opts::FPTOL ) {
     T hp1 = target( xk, args... ) / dTarget( xk, args... );
     T h   = target( xkm1, args... ) / dTarget( xkm1, args... );


### PR DESCRIPTION
Fix in anderson accelerated solvers. The first iteration of fixed point can sometimes immediately converge, leading to issues in the following iterations. Adds a check for this. Now the Anderson accelerated fixed point solve works with Saha.